### PR TITLE
bump version to 0.1.2, update README and man page, enhance restore fu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ outputs/
 restitch_tmp/
 dist/
 backups/
+restitch_tmp_selected.manifest.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "restitch"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restitch"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Prompts you before overwriting current files with a backup from `./backups/`.
 Visit the [Releases Page](https://github.com/JakeTurner616/restitch/releases) and download the archive for your platform:
 
 ```bash
-tar -xzf restitch-v0.1.1-x86_64-unknown-linux-gnu.tar.gz
-sudo cp restitch-v0.1.1-x86_64-unknown-linux-gnu/restitch /usr/local/bin/
+tar -xzf restitch-v0.1.2-x86_64-unknown-linux-gnu.tar.gz
+sudo cp restitch-v0.1.2-x86_64-unknown-linux-gnu/restitch /usr/local/bin/
 ```
 
 > Also available for: `aarch64-unknown-linux-gnu`.
@@ -129,4 +129,4 @@ sudo cp target/release/restitch /usr/local/bin/
 
 [MIT License](LICENSE) — free to use, modify, and distribute.
 
-> Built for terminal users who actually care about their configs.
+> Built for terminal users who care about backing up their configs.

--- a/man/restitch.1
+++ b/man/restitch.1
@@ -1,4 +1,4 @@
-.TH RESTITCH 1 "June 2025" "v0.1.1" "User Commands"
+.TH RESTITCH 1 "June 2025" "v0.1.2" "User Commands"
 .SH NAME
 restitch \- backup, restore, and revert Linux config files
 .SH SYNOPSIS

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -2,7 +2,7 @@
 set -e
 
 APP_NAME="restitch"
-VERSION="v0.1.1"
+VERSION="v0.1.2"
 DIST_DIR="dist"
 
 # Always build for Linux

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-// main.rs
-
 mod tui;
 mod detectors;
 mod packager;
@@ -8,16 +6,19 @@ mod restore;
 mod revert;
 
 use clap::Parser;
+use std::fs;
+use std::io;
+use std::process;
 
-/// Restitc CLI – Export, Restore, or Revert Linux Configs
+/// Restitch CLI – Export, Restore, or Revert Linux Configs
 #[derive(Parser, Debug)]
 #[command(author, version, about = "🌀 Restitch – Export, Restore, or Revert Linux Configs")]
 struct Args {
-    /// Enable restore mode
+    /// Enable restore mode (TUI if no archive/manifest given)
     #[arg(long)]
     restore: bool,
 
-    /// Enable revert mode
+    /// Enable revert mode (TUI interface)
     #[arg(long)]
     revert: bool,
 
@@ -38,26 +39,63 @@ struct Args {
     config_path: String,
 }
 
-
-
 fn main() {
+    // Ensure unexpected panics do not corrupt terminal or print gibberish
+    std::panic::set_hook(Box::new(|info| {
+        eprintln!("❌ Unexpected fatal error: {}", info);
+        process::exit(1);
+    }));
+
     let args = Args::parse();
 
     // 🚫 Invalid usage: dry-run without --restore
     if args.dry_run && !args.restore {
         eprintln!("❌ '--dry-run' can only be used with '--restore'");
-        std::process::exit(1);
+        process::exit(1);
     }
 
+    // 🔁 Revert (always uses TUI selector)
     if args.revert {
-        revert::revert();
+        if let Err(e) = revert::run_revert_ui() {
+            eprintln!("❌ Revert UI error: {}", e);
+            process::exit(1);
+        }
     }
+    // 🔄 Restore (TUI if no archive/manifest provided)
     else if args.restore {
-        let archive = args.archive.unwrap_or_else(|| "outputs/restitch-archive.tar.gz".to_string());
-        let manifest = args.manifest.unwrap_or_else(|| "outputs/restitch-archive.manifest.toml".to_string());
-        restore::restore_configs(&archive, &manifest, args.dry_run);
-    } else {
-        match tui::run_ui_with_config(&args.config_path) {
+        let archive = args.archive.clone().unwrap_or_default();
+        let manifest = args.manifest.clone().unwrap_or_default();
+
+        if archive.is_empty() || manifest.is_empty() {
+            // No explicit paths → launch TUI restore interface
+            if let Err(e) = restore::run_restore_ui(
+                "outputs/restitch-archive.manifest.toml",
+                "outputs/restitch-archive.tar.gz",
+                args.dry_run,
+            ) {
+                eprintln!("❌ Restore UI error: {}", e);
+                process::exit(1);
+            }
+        } else {
+            // Check that manifest exists and is readable
+            match fs::read_to_string(&manifest) {
+                Ok(_) => {
+                    restore::restore_configs(&archive, &manifest, args.dry_run);
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                    eprintln!("❌ Manifest file not found: '{}'", manifest);
+                    process::exit(1);
+                }
+                Err(err) => {
+                    eprintln!("❌ Failed to read manifest '{}': {}", manifest, err);
+                    process::exit(1);
+                }
+            }
+        }
+    }
+    // 📦 Default mode: Package (TUI for selecting configs)
+    else {
+        match tui::run_ui_with_cleanup(&args.config_path) {
             Ok(items) => {
                 if items.is_empty() {
                     println!("⚠️ No config items selected. Nothing to export.");
@@ -67,7 +105,7 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("❌ UI error: {}", e);
-                std::process::exit(1);
+                process::exit(1);
             }
         }
     }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -1,22 +1,30 @@
-use crate::config::ConfigManifest;
+use crate::config::{ConfigItem, ConfigManifest};
 use chrono::Local;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tar::Archive;
 
-/// Restores configs from a backup archive using a manifest, optionally as a dry-run
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use tui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Modifier, Style},
+    text::Span,
+    widgets::{Block, Borders, List, ListItem, ListState},
+    Terminal,
+};
+
 pub fn restore_configs(archive_path: &str, manifest_path: &str, dry_run: bool) {
-    // Validate both files exist
     if !Path::new(archive_path).exists() || !Path::new(manifest_path).exists() {
         println!("❌ Archive or manifest not found.\n");
         println!("Restitch could not find the default archive or manifest file in:");
         println!("  • {}", archive_path);
         println!("  • {}\n", manifest_path);
-        println!("💡 To restore configs, either:");
-        println!("  1. First run `restitch` and export a config archive.");
-        println!("  2. Or pass custom paths to an archive and manifest like so:");
-        println!("     restitch --restore path/to/archive.tar.gz path/to/manifest.toml\n");
         std::process::exit(1);
     }
 
@@ -26,9 +34,7 @@ pub fn restore_configs(archive_path: &str, manifest_path: &str, dry_run: bool) {
     let mut archive = Archive::new(decompressor);
 
     fs::create_dir_all("restitch_tmp").expect("❌ Could not create temp extraction directory");
-    archive
-        .unpack("restitch_tmp")
-        .expect("❌ Failed to extract archive");
+    archive.unpack("restitch_tmp").expect("❌ Failed to extract archive");
 
     println!("📂 Extracted to: restitch_tmp/\n");
 
@@ -63,47 +69,58 @@ pub fn restore_configs(archive_path: &str, manifest_path: &str, dry_run: bool) {
                 ""
             }
         );
-
-        if !dry_run {
-            fs::create_dir_all(backup_path.parent().unwrap())
-                .expect("❌ Could not create backup directory");
-
-            if Path::new(&item.path).exists() {
-                fs::rename(&item.path, &backup_path)
-                    .expect("❌ Failed to back up existing file");
-            }
-
-            let extracted_path = Path::new("restitch_tmp").join(rel_path);
-            fs::create_dir_all(Path::new(&item.path).parent().unwrap())
-                .expect("❌ Could not create destination directory");
-
-            if extracted_path.is_dir() {
-                copy_dir_recursive(&extracted_path, Path::new(&item.path))
-                    .expect("❌ Failed to copy directory");
-            } else {
-                fs::copy(&extracted_path, &item.path)
-                    .expect("❌ Failed to copy file");
-            }
-        }
     }
 
     if dry_run {
         println!("\n🔎 Restore dry-run complete.");
-        println!("👉 If the above plan looks correct, run with `--restore` (no --dry-run) to apply the changes.");
-        println!("💡 All listed config files would be overwritten, and existing versions backed up.");
-        println!("💡 Directory paths will restore all nested files and subdirectories from the archive.");
-        println!("💡 You can undo applied changes at any time by running: `restitch --revert`");
-        println!("───────────────────────────────────────────────");
-    } else {
-        println!("\n✅ Restore completed successfully.");
-        println!("📁 Backups saved to: backups/{}/", timestamp);
-        println!("💡 You can revert these changes at any time by running: `restitch --revert`.");
-        println!("───────────────────────────────────────────────");
+        return;
     }
+
+    // 🛑 Prompt confirmation before continuing
+    println!("\n⚠️  This operation will overwrite the above config files.");
+    print!("Proceed with restore? [y/N]: ");
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).unwrap();
+    if input.trim().to_lowercase() != "y" {
+        println!("\n❌ Restore cancelled.");
+        return;
+    }
+
+    // 🛠️ Perform actual restore
+    for item in &manifest.items {
+        let rel_path = Path::new(&item.path)
+            .strip_prefix(home.to_str().unwrap())
+            .unwrap_or(Path::new(&item.path));
+        let backup_path = backup_dir.join(rel_path);
+
+        fs::create_dir_all(backup_path.parent().unwrap())
+            .expect("❌ Could not create backup directory");
+
+        if Path::new(&item.path).exists() {
+            fs::rename(&item.path, &backup_path)
+                .expect("❌ Failed to back up existing file");
+        }
+
+        let extracted_path = Path::new("restitch_tmp").join(rel_path);
+        fs::create_dir_all(Path::new(&item.path).parent().unwrap())
+            .expect("❌ Could not create destination directory");
+
+        if extracted_path.is_dir() {
+            copy_dir_recursive(&extracted_path, Path::new(&item.path))
+                .expect("❌ Failed to copy directory");
+        } else {
+            fs::copy(&extracted_path, &item.path)
+                .expect("❌ Failed to copy file");
+        }
+    }
+
+    println!("\n✅ Restore completed successfully.");
+    println!("📁 Backups saved to: backups/{}/", timestamp);
 }
 
-/// Recursively copy a directory
-fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+pub fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
@@ -116,4 +133,128 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+pub fn run_restore_ui(manifest_path: &str, archive_path: &str, dry_run: bool) -> io::Result<()> {
+    let manifest_str = fs::read_to_string(manifest_path)?;
+    let manifest: ConfigManifest = toml::from_str(&manifest_str)
+        .expect("❌ Invalid manifest format");
+
+    let mut items: Vec<ConfigItem> = manifest.items
+        .into_iter()
+        .map(|mut item| { item.selected = true; item })
+        .collect();
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let result = ui_loop(&mut terminal, &mut items, dry_run);
+
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    if let Ok(true) = result {
+        let selected_items: Vec<ConfigItem> = items
+            .into_iter()
+            .filter(|i| i.selected)
+            .collect();
+
+        if selected_items.is_empty() {
+            println!("❌ No items selected.");
+        } else {
+            let temp_manifest = ConfigManifest { items: selected_items };
+            let temp_manifest_str = toml::to_string(&temp_manifest).unwrap();
+            fs::write("restitch_tmp_selected.manifest.toml", &temp_manifest_str)?;
+            restore_configs(archive_path, "restitch_tmp_selected.manifest.toml", dry_run);
+        }
+    }
+
+    Ok(())
+}
+
+fn ui_loop<B: tui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    items: &mut Vec<ConfigItem>,
+    dry_run: bool,
+) -> io::Result<bool> {
+    // Handle config loading errors BEFORE enabling terminal features
+    let mut state = ListState::default();
+    if !items.is_empty() {
+        state.select(Some(0));
+    }
+
+    loop {
+        terminal.draw(|f| {
+            let size = f.size();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(2)].as_ref())
+                .split(size);
+
+            let list_items: Vec<ListItem> = items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| {
+                    let prefix = if item.selected { "[x]" } else { "[ ]" };
+                    let line = format!("{} {}", prefix, item.name);
+                    let style = if state.selected() == Some(i) {
+                        Style::default().add_modifier(Modifier::REVERSED)
+                    } else {
+                        Style::default()
+                    };
+                    ListItem::new(Span::raw(line)).style(style)
+                })
+                .collect();
+
+            let list = List::new(list_items)
+                .block(Block::default().title("🌀 Restitch: Restore Configs").borders(Borders::ALL))
+                .highlight_symbol(">>");
+
+            f.render_stateful_widget(list, chunks[0], &mut state);
+
+            let help_text = if dry_run {
+                "↑↓: Navigate  ␣: Toggle  enter: Run Dry-run  q: Quit"
+            } else {
+                "↑↓: Navigate  ␣: Toggle  enter: Restore  q: Quit"
+            };
+
+            let help = Block::default().title(help_text).borders(Borders::ALL);
+            f.render_widget(help, chunks[1]);
+        })?;
+
+        if event::poll(std::time::Duration::from_millis(200))? {
+            match event::read()? {
+                Event::Key(key) => match key.code {
+                    KeyCode::Char('q') => return Ok(false),
+                    KeyCode::Enter => return Ok(true),
+                    KeyCode::Down => {
+                        if let Some(i) = state.selected() {
+                            let next = if i >= items.len() - 1 { 0 } else { i + 1 };
+                            state.select(Some(next));
+                        }
+                    }
+                    KeyCode::Up => {
+                        if let Some(i) = state.selected() {
+                            let prev = if i == 0 { items.len() - 1 } else { i - 1 };
+                            state.select(Some(prev));
+                        }
+                    }
+                    KeyCode::Char(' ') => {
+                        if let Some(i) = state.selected() {
+                            items[i].selected = !items[i].selected;
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
 }


### PR DESCRIPTION
### TUI Corrupted ANSII cleanup failure fix, Bump to v0.1.2

#### Summary

This PR improves the robustness of `restitch`'s TUI handling and error recovery, bumping the version to **v0.1.2**.

#### Changes

* **Fixed terminal corruption on failure**:

  * Refactored `scan_targets_from_file()` to return `Result` instead of calling `exit(1)`
  * Ensured terminal modes (raw/alt screen) are restored even on config load failures
* **Improved error messages** for invalid or missing config files
* **Added graceful UI error fallback** before TUI initialization

All TUI paths should now:

* Exit cleanly when the config or manifest is invalid
* Never leave the terminal in a broken state
* Provide helpful error feedback without crashing
